### PR TITLE
Feat/76-result-fail-page

### DIFF
--- a/src/app/result/failed/page.tsx
+++ b/src/app/result/failed/page.tsx
@@ -9,9 +9,8 @@ const SquareBackground = styled.div`
   display: flex;
   flex-direction: column;
   align-items: center;
-  padding: 27px;
   gap: 24px;
-  width: 360px;
+  width: 380px;
   height: 293px;
   background: #f9f9fa;
   border-radius: 16px;
@@ -48,13 +47,13 @@ function FinishPage() {
             </Col>
             <Col align="center">
               <SquareBackground>
-                <Paddle left={24} right={24} bottom={90} top={28}>
+                <Paddle top={28} bottom={90}>
                   <Col align="center" gap={24}>
                     <Text label="😢" weight={400} size="4xl" />
                     <Text
                       label={`한정된 인원으로 매칭에\n어려움이 생겼음을 알려드립니다.\n다음 시즌에 더욱 좋은 서비스로 보답하겠습니다.\n관심을 갖고 이벤트에 참여해 주셔서 감사합니다.`}
                       weight={400}
-                      size="sm"
+                      size="base"
                       color="#808A98"
                     />
                   </Col>
@@ -67,7 +66,6 @@ function FinishPage() {
       <BottomSelectWrapper>
         <Button
           primary="active"
-          color="#34AAFF"
           textSize="sm"
           onClick={() => router.push('/')}
           label="홈 화면으로 돌아가기"

--- a/src/app/result/failed/page.tsx
+++ b/src/app/result/failed/page.tsx
@@ -9,7 +9,7 @@ const SquareBackground = styled.div`
   display: flex;
   flex-direction: column;
   align-items: center;
-  padding: 28px, 24px;
+  padding: 27px;
   gap: 24px;
   width: 360px;
   height: 293px;
@@ -26,7 +26,7 @@ const BottomSelectWrapper = styled.div`
   bottom: 0;
   display: flex;
   flex-direction: column;
-  padding: 16px 24px;
+  padding: 16px 40px;
   width: 100%;
 `;
 
@@ -54,7 +54,7 @@ function FinishPage() {
                     <Text
                       label={`한정된 인원으로 매칭에\n어려움이 생겼음을 알려드립니다.\n다음 시즌에 더욱 좋은 서비스로 보답하겠습니다.\n관심을 갖고 이벤트에 참여해 주셔서 감사합니다.`}
                       weight={400}
-                      size="base"
+                      size="sm"
                       color="#808A98"
                     />
                   </Col>
@@ -66,7 +66,8 @@ function FinishPage() {
       </Col>
       <BottomSelectWrapper>
         <Button
-          primary="inactive"
+          primary="active"
+          color="#34AAFF"
           textSize="sm"
           onClick={() => router.push('/')}
           label="홈 화면으로 돌아가기"

--- a/src/app/result/failed/page.tsx
+++ b/src/app/result/failed/page.tsx
@@ -1,0 +1,78 @@
+'use client';
+
+import styled from 'styled-components';
+import React from 'react';
+import { useRouter } from 'next/navigation';
+import { Button, Col, Paddle, Text, ProgressHeader } from '@/components';
+
+const SquareBackground = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  padding: 28px, 24px;
+  gap: 24px;
+  width: 360px;
+  height: 293px;
+  background: #f9f9fa;
+  border-radius: 16px;
+  flex: none;
+  order: 1;
+  flex-grow: 0;
+`;
+
+const BottomSelectWrapper = styled.div`
+  position: fixed;
+  max-width: 414px;
+  bottom: 0;
+  display: flex;
+  flex-direction: column;
+  padding: 16px 24px;
+  width: 100%;
+`;
+
+function FinishPage() {
+  const router = useRouter();
+
+  return (
+    <>
+      <ProgressHeader
+        isprogress={false}
+        isprogressbar={false}
+        title="매칭 결과"
+      />
+      <Col fill>
+        <Paddle top={76} right={27} left={27}>
+          <Col align="center" gap={42}>
+            <Col align="center">
+              <Text label="매칭이 실패하였습니다." weight={800} size="xl" />
+            </Col>
+            <Col align="center">
+              <SquareBackground>
+                <Paddle left={24} right={24} bottom={90} top={28}>
+                  <Col align="center" gap={24}>
+                    <Text label="😢" weight={400} size="4xl" />
+                    <Text
+                      label={`한정된 인원으로 매칭에\n어려움이 생겼음을 알려드립니다.\n다음 시즌에 더욱 좋은 서비스로 보답하겠습니다.\n관심을 갖고 이벤트에 참여해 주셔서 감사합니다.`}
+                      weight={400}
+                      size="base"
+                      color="#808A98"
+                    />
+                  </Col>
+                </Paddle>
+              </SquareBackground>
+            </Col>
+          </Col>
+        </Paddle>
+      </Col>
+      <BottomSelectWrapper>
+        <Button
+          primary="inactive"
+          textSize="sm"
+          onClick={() => router.push('/')}
+          label="홈 화면으로 돌아가기"
+        />
+      </BottomSelectWrapper>
+    </>
+  );
+}
+export default FinishPage;


### PR DESCRIPTION
# 매칭 결과 실패 페이지 제작 완료

## 변경사항

- figma 상에 나와 있는 회색 배경 상자의 width대로 하면 텍스트의 줄바꿈이 일어나, width를 약간 늘려서 줄바꿈이 일어나지 않게 변경했습니다.
- figma 상에 나와 있는 버튼의 색상은 버튼 컴포넌트에서 선택할 수 있는 옵션이 없어서, 최대한 비슷한 primary="active"일 때의 짙은 파란색 색상의 버튼으로 대체했습니다. figma상에 나와 있는 버튼 색상대로 하려면 Button 컴포넌트의 수정이 필요한 것 같습니다!