### PR TITLE
Feat/72-check-apply-information-page

### DIFF
--- a/src/components/molecules/teamStatusBox/TeamStatusBox.tsx
+++ b/src/components/molecules/teamStatusBox/TeamStatusBox.tsx
@@ -41,7 +41,12 @@ const TeamStatusBox = ({ teamName, type, status }: TeamStatusBoxProps) => {
         <Text label={`“${teamName}”`} weight={800} size="xl" color="#656D78" />
       </Col>
       <Col gap={8}>
-        <Row justify={'space-between'} align={'center'} width="full">
+        <Row
+          justify={'space-between'}
+          align={'center'}
+          padding={'0 20px'}
+          width="full"
+        >
           <Row align={'center'}>
             {isWaiting && <S.Loader />}
             <Text

--- a/src/page/common/ConfirmStep.tsx
+++ b/src/page/common/ConfirmStep.tsx
@@ -2,7 +2,7 @@
 
 import { useState } from 'react';
 
-import { Footer } from '@/components';
+import { Col, Footer, ResultBox, TeamStatusBox, Text } from '@/components';
 
 import { useAppDispatch, useAppSelector } from '@/store/hooks';
 import {
@@ -15,7 +15,7 @@ import { PERSONAL_MAX_PAGE_ARR, GROUP_LEADER_MAX_PAGE_ARR } from '@/constants';
 
 const ConfirmStep = () => {
   const [isFinishPage, setIsFinishPage] = useState(false);
-
+  const group = 'group';
   const { curStep, meetingType } = useAppSelector(state => state.applyInfo);
   const dispatch = useAppDispatch();
   const isPersonal = meetingType === 'personal';
@@ -35,14 +35,40 @@ const ConfirmStep = () => {
   };
 
   return (
-    <>
+    <Col padding={'40px 16px'}>
+      <Col gap={40}>
+        <Col align={'center'} gap={8}>
+          <Text
+            label="📌 신청 정보를 확인해주세요!"
+            size="xl"
+            color="#3B4046"
+            weight={800}
+          />
+          <Text
+            label="신청 완료 후에는 수정이 불가합니다."
+            size="sm"
+            color="#656D78"
+          />
+        </Col>
+        <Col gap={12}>
+          {group === 'group' && (
+            <TeamStatusBox
+              teamName={'건공관 지박령'}
+              type={'confirm'}
+              status={'complete'}
+            />
+          )}
+          <ResultBox title={'상대 팅에게 보여지는 정보'} applyDataArr={[]} />
+          <ResultBox title={'원하는 팅의 정보'} applyDataArr={[]} />
+        </Col>
+      </Col>
       <Footer
         maxPage={1}
         disabled={isFinishPage}
         onClickPrev={onClickPrev}
         onClickNext={onClickNext}
       />
-    </>
+    </Col>
   );
 };
 


### PR DESCRIPTION
# 신청 정보 확인 페이지 제작

## 상세설명
1. store에서 meetingType 데이터를 불러올 때, meetingTpye === 'group'이면 우리 팅 정보를 보여주는 분기 처리를 진행했습니다.
2. 신청 정보 확인 페이지입니다.
<img width="277" alt="image" src="https://github.com/uoslife/client-meeting-season3/assets/89263598/42537321-57f5-4be1-87d0-4d205d1271d6">

<img width="276" alt="image" src="https://github.com/uoslife/client-meeting-season3/assets/89263598/c4174dbd-3473-4c45-b91b-eee591f1c1e5">

## Close
close #72 