### PR TITLE
fix: 노션 배포 전 ux 디자인 개선

### DIFF
--- a/src/app/apply/complete/page.tsx
+++ b/src/app/apply/complete/page.tsx
@@ -6,6 +6,7 @@ import { Button, Col, Paddle, Text } from '@/components';
 import { useEffect, useRef } from 'react';
 import congratulation from '@/assets/lottie/congratulation.json';
 import { useRouter } from 'next/navigation';
+import { colors } from '@/styles/styles';
 
 const BottomSelectWrapper = styled.div`
   position: fixed;
@@ -57,10 +58,14 @@ const FinishPage = () => {
 
             <Col align={'center'} gap={8}>
               <Col align={'center'}>
-                <Text label="05/28 일요일 저녁!" weight={600} />
+                <Text label="06/01 목요일 저녁!" weight={600} />
                 <Text label="시대생 어플로 알림을 보내드려요." />
               </Col>
-              <Text label="(신청 취소 기한: 5월 27일 자정까지)" />
+              <Text
+                color={colors.Primary_500}
+                size={'xs'}
+                label="(신청 취소 기한: 5월 31일 오후 10시까지)"
+              />
             </Col>
           </Col>
         </Paddle>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -10,6 +10,7 @@ import { SOCIAL_LINK } from '@/constants';
 import { useRouter } from 'next/navigation';
 import { useState } from 'react';
 import { useAppSelector } from '@/store/store';
+import { colors } from '@/styles/styles';
 
 const Main = () => {
   const router = useRouter();
@@ -61,7 +62,7 @@ const Main = () => {
             label="시대팅 시즌 3"
             size="4xl"
             font="LeferiPoint-SpecialA"
-            color="#2E74FF"
+            color={colors.Primary_500}
           />
         </S.MainTextWrapper>
         <div style={{ textAlign: 'center' }}>

--- a/src/components/buttons/interstSelectButton/InterestSelectButton.tsx
+++ b/src/components/buttons/interstSelectButton/InterestSelectButton.tsx
@@ -32,7 +32,7 @@ const InterestSelectButton = ({
           height={54}
         />
       </S.ImgWrapper>
-      <Text label={label} weight={600} color={'#808A98'} />
+      <Text label={label} size={'sm'} weight={600} color={'#808A98'} />
     </S.Wrapper>
   );
 };

--- a/src/components/header/progressHeader/ProgressHeader.tsx
+++ b/src/components/header/progressHeader/ProgressHeader.tsx
@@ -12,6 +12,7 @@ import {
   SOCIAL_LINK,
 } from '@/constants';
 import { useEffect, useState } from 'react';
+import { useRouter } from 'next/navigation';
 
 export type ProgressHeaderProps = {
   isprogress: boolean;
@@ -24,6 +25,7 @@ const ProgressHeader = ({
   isprogressbar = false,
   title,
 }: ProgressHeaderProps) => {
+  const router = useRouter();
   const { meetingType, curStep } = useAppSelector(state => state.applyInfo);
 
   const [maxStep, setMaxStep] = useState(0);
@@ -61,7 +63,7 @@ const ProgressHeader = ({
     <S.Wrapper>
       <S.Container isprogress={isprogress}>
         <Row justify={'space-between'} align={'center'} fill>
-          <S.SocialLink href={SOCIAL_LINK.Uoslife}>
+          <S.SocialLink onClick={() => router.push('/')}>
             <IconButton iconName="Home" width={24} height={24} />
           </S.SocialLink>
           <S.HeaderTitle>{title || returnTitleByMeetingType()}</S.HeaderTitle>

--- a/src/components/modal/bottomSheet/BottomSheet.style.tsx
+++ b/src/components/modal/bottomSheet/BottomSheet.style.tsx
@@ -63,27 +63,25 @@ export const Sheet = styled.div<BottomSheetProps>`
 
 export const Button = styled.div<BottomSheetProps>`
   all: unset;
-  box-sizing: border-box;
 
   display: flex;
   justify-content: center;
   align-items: center;
   flex-shrink: 0;
-  height: 52px;
   cursor: pointer;
 
   ${({ type }) => {
     switch (type) {
       case 'primary':
         return css`
-          padding: 25px 80px;
+          padding: 12px 55px;
           background: ${colors.Primary_500};
           color: ${colors.White};
           border-radius: 8px;
         `;
       case 'white':
         return css`
-          padding: 25px 80px;
+          padding: 12px 55px;
           background: ${colors.Secondary100};
           color: ${colors.Black};
           border-radius: 12px;

--- a/src/components/molecules/resultBox/ResultBox.tsx
+++ b/src/components/molecules/resultBox/ResultBox.tsx
@@ -26,12 +26,20 @@ const ResultBox = ({ title, applyDataArr }: ResultBoxProps) => {
     }
     // mbti
     if (data.title_en === 'mbti' && data.type === 'info')
-      return (data.data as string[]).join('');
+      return (data.data as string[]).join(', ');
     if (data.title_en === 'mbti' && data.type === 'prefer')
       return (data.data as string[]).join(', ');
     // 기피학과
     // if (data.title_en === 'major' && data.type === 'prefer')
     // return (data.data as string[]).join('');
+
+    if (data.title_en === 'height' && data.type === 'prefer')
+      return `${parseInt(data.data[0])} ~ ${parseInt(data.data[1])}`;
+
+    if (data.title_en === 'age' && data.type === 'prefer') {
+      const formattedData = data.data?.map(item => item.replace(/~/g, ''));
+      return `${parseInt(formattedData[0])} ~ ${parseInt(formattedData[1])}`;
+    }
 
     switch (typeof data.data) {
       case 'string':

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -1,5 +1,6 @@
 export const SOCIAL_LINK = {
-  Sharelink: 'https://www.instagram.com/p/CpEycd2yep6/?igshid=MjkzY2Y1YTY=',
+  Sharelink:
+    'https://www.instagram.com/p/Cskqlsyy9Ar/?utm_source=ig_web_copy_link&igshid=MmJiY2I4NDBkZg==',
   Instagram: 'https://www.instagram.com/uoslife_official/',
   Kakaotalk: 'https://pf.kakao.com/_gMEHK',
   Uoslife: 'https://uoslife.com/',
@@ -105,7 +106,6 @@ export const ANIMALS = [
 export const AGE_ARR = [
   20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35,
 ];
-
 export const AGE_SLIDER_ARR = [
   '20',
   '21',

--- a/src/page/common/ConfirmStep.tsx
+++ b/src/page/common/ConfirmStep.tsx
@@ -73,7 +73,7 @@ const ConfirmStep = () => {
         <Col gap={12}>
           {!isPersonal && (
             <TeamStatusBox
-              teamName={'건공관 지박령'}
+              teamName={groupState.info_name.data}
               type={'confirm'}
               status={'complete'}
             />

--- a/src/page/groupLeader/SecondStep/SecondPage.tsx
+++ b/src/page/groupLeader/SecondStep/SecondPage.tsx
@@ -13,8 +13,10 @@ import {
 import * as S from '@/styles/pages/GroupLeaderPage.style';
 
 import { useState } from 'react';
+import { useAppSelector } from '@/store/store';
 
 const SecondPage = ({ setIsFinishPage }: StepProps) => {
+  const { info_name } = useAppSelector(state => state.group);
   const [code, setCode] = useState(8250);
   setIsFinishPage(true);
   return (
@@ -26,6 +28,7 @@ const SecondPage = ({ setIsFinishPage }: StepProps) => {
             <Text
               label="팅 코드를 팅원에게 공유해주세요."
               size="xl"
+              weight={600}
               color="#656D78"
             />
             <Text
@@ -44,7 +47,7 @@ const SecondPage = ({ setIsFinishPage }: StepProps) => {
         />
         <S.Divider />
         <TeamStatusBox
-          teamName={'건공관 지박령'}
+          teamName={info_name.data}
           type={'apply'}
           status={'waiting'}
         />

--- a/src/page/personal/FirstStep/FifthPage.tsx
+++ b/src/page/personal/FirstStep/FifthPage.tsx
@@ -25,7 +25,7 @@ const FifthPage = ({ setIsFinishPage }: StepProps) => {
     <Col gap={32} padding={'32px 24px'}>
       <Col align={'center'}>
         <Text
-          label={'11. 본인의 관심사를 3가지 선택해주세요.'}
+          label={'10. 본인의 관심사를 3가지 선택해주세요.'}
           color={'#3B4046'}
           weight={700}
         />

--- a/src/page/personal/FirstStep/FourthPage.tsx
+++ b/src/page/personal/FirstStep/FourthPage.tsx
@@ -26,7 +26,7 @@ const FourthPage = ({ setIsFinishPage }: StepProps) => {
   return (
     <Paddle top={32} left={35} right={35}>
       <Col gap={30} align={'center'}>
-        <Text weight={700} label={'10. 본인의 MBTI를 선택해주세요.'} />
+        <Text weight={700} label={'9. 본인의 MBTI를 선택해주세요.'} />
         <Col gap={34}>
           {mbtiValue?.map((item, i) => {
             return (

--- a/src/page/personal/ThirdStep/FirstPage.tsx
+++ b/src/page/personal/ThirdStep/FirstPage.tsx
@@ -27,7 +27,7 @@ const FirstPage = ({ setIsFinishPage }: StepProps) => {
     studentTypeButtonActiveState,
     isClickedStudentType,
     studentType,
-  ] = useClickButton(studentTypeArr, 1, prefer_studentType);
+  ] = useClickButton(studentTypeArr, 3, prefer_studentType);
 
   useEffect(() => {
     console.log(prefer_age.data);

--- a/src/page/personal/ThirdStep/FourthPage.tsx
+++ b/src/page/personal/ThirdStep/FourthPage.tsx
@@ -35,7 +35,7 @@ const FourthPage = ({ setIsFinishPage }: StepProps) => {
         <Text
           weight={700}
           font={'LeferiBaseType-RegularA'}
-          label={'10. 선호하는 상대의 MBTI를 선택해주세요.'}
+          label={'7. 선호하는 상대의 MBTI를 선택해주세요.'}
         />
         <Text
           color={colors.Secondary700}

--- a/src/page/personal/ThirdStep/ThirdPage.tsx
+++ b/src/page/personal/ThirdStep/ThirdPage.tsx
@@ -32,7 +32,7 @@ function ThirdPage({ setIsFinishPage }: StepProps) {
     <Col gap={44} padding={'32px 24px'}>
       <Col align={'center'} gap={12}>
         <Text
-          label={'8. 선호하는 상대의 동물상을 선택해주세요.'}
+          label={'6. 선호하는 상대의 동물상을 선택해주세요.'}
           color={'#3B4046'}
           weight={700}
         />

--- a/src/styles/pages/page.style.tsx
+++ b/src/styles/pages/page.style.tsx
@@ -1,4 +1,5 @@
 import styled from 'styled-components';
+import { colors } from '@/styles/styles';
 
 export const MainWrapper = styled.main`
   display: flex;
@@ -33,7 +34,7 @@ export const MainTextWrapper = styled.div`
   justify-content: center;
   align-items: flex-start;
   padding: 8px 28px;
-  border: 1px solid #2e74ff;
+  border: 1px solid ${colors.Primary_500};
   border-radius: 12px;
   opacity: 0.9;
 `;


### PR DESCRIPTION
# 노션 배포 전 ux 디자인 개선

## 변경사항

###폰트 
Leferi Point Type / Leferi Point Type / Inter → 모두 Pretendard로 수정
→ 추후 수정 예정

###1대1 - 01. 나의 정보 입력하기
본인 MBTI 질문 번호 9번으로 수정
본인 MBTI Q마다 버튼 하나씩 눌러야만 다음페이지 버튼 활성화되게 수정
1대1 - 0.3 선호하는 상대 정보 입력하기
3.선호하는 상대 신분 복수 선택으로 수정(현재 복수x) → 업데이트 후 확인
선호 상대 MBTI 질문 번호 9번으로 수정
1대1 - 04. 신청 정보 확인하기
선호사항 - **“나이”와 “키”**의 출력값을 “23-28”과 “160-180” 형태로 수정
MBTI - 선택된 모든 내용 “E, I, S, T, F, P”과 같은 형태로 출력
1대1 - 신청 완료 페이지
05/28 일요일 저녁! → 05/29 월요일 저녁! 으로 수정
신청 취소 기한: 5월 28일 오후 10시까지 → 색상도 파란색으로 수정
"시대팅 안내” 버튼 삭제**
신청 정보 확인하기" 버튼 작동 안 됨**
3대3(팅장) - 02. 팅 만들기
팅 이름 “건공관 지박령”으로 고정된 상태 → 입력 정보 일치시키기
3대3(팅장) - 04. 만나고 싶은 팅 정보 입력하기
2.매칭 기피 학과 입력 텍스트창 생성
3대3(팅원) - 01. 나의 정보 입력하기
5.본인 학과 선택 - 2개 이상 선택 안 됨(내 폰의 오류일 수도!) 한 번 확인 바람

###후순위
[랜딩페이지] “시대팅 시즌 3” 박스, 텍스트의 색상 수정
[랜딩페이지] 공유링크 복사 아이콘 수정(그림자x)
1대1 - [01.나의정보입력하기] 5. 본인 학과 → 선택된 학과 (0개) 왼쪽 정렬
1대1 - [01.나의정보입력하기] 11. 관심사 “독서, 운동, 게임 등” 텍스트 크기 축소화
3대3 - [02. 팅 만들기] “팅 코드를 팅원에게 공유해주세요” 텍스트 크기 축소화
3대3(팅원) - 02. 팅 만들기
코드 입력 후 팅 참여 모달의 “취소/참여” 버튼 축소화